### PR TITLE
implement MapGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
             <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/src/main/java/io/javarig/OldRandomGenerator.java
+++ b/src/main/java/io/javarig/OldRandomGenerator.java
@@ -7,7 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.Contract;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;

--- a/src/main/java/io/javarig/ParameterizedTypeImpl.java
+++ b/src/main/java/io/javarig/ParameterizedTypeImpl.java
@@ -1,0 +1,31 @@
+package io.javarig;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public class ParameterizedTypeImpl implements ParameterizedType {
+    private final Type[] actualTypeArguments;
+    private final Class<?>  rawType;
+    private final Type   ownerType;
+
+    public ParameterizedTypeImpl(Type[] actualTypeArguments, Class<?> rawType, Type ownerType) {
+        this.actualTypeArguments = actualTypeArguments;
+        this.rawType = rawType;
+        this.ownerType = ownerType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return actualTypeArguments;
+    }
+
+    @Override
+    public Type getRawType() {
+        return rawType;
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return ownerType;
+    }
+}

--- a/src/main/java/io/javarig/RandomGenerator.java
+++ b/src/main/java/io/javarig/RandomGenerator.java
@@ -17,11 +17,9 @@ public class RandomGenerator {
         objectStack.push(type);
         TypeEnum typeEnum = TypeEnum.fromType(type);
         Generator generator = typeEnum.generator();
-        //the part that changes
         if (generator instanceof CollectionGenerator collectionGenerator) {
             setCollectionSize.accept(collectionGenerator);
         }
-        //
         T generated = (T) generator.generate(type);
         objectStack.pop();
         return generated;
@@ -41,6 +39,11 @@ public class RandomGenerator {
             collectionGenerator.setMinSize(minSize);
             collectionGenerator.setMaxSize(maxSize);
         });
+    }
+
+    public <T> T generate(Type type, Type... genericTypes) {
+        Type parameterizedType = new ParameterizedTypeImpl(genericTypes,(Class<?>) type,null);
+        return generate(parameterizedType);
     }
 
     /**

--- a/src/main/java/io/javarig/RandomGenerator.java
+++ b/src/main/java/io/javarig/RandomGenerator.java
@@ -12,7 +12,7 @@ public class RandomGenerator {
     private final Stack<Type> objectStack = new Stack<>();
 
     @SuppressWarnings({"unchecked"})
-    private <T> T generate(Type type, Consumer<CollectionGenerator> setCollectionSize) {
+    private synchronized <T> T generate(Type type, Consumer<CollectionGenerator> setCollectionSize) {
         checkForRecursion(type);
         objectStack.push(type);
         TypeEnum typeEnum = TypeEnum.fromType(type);
@@ -20,7 +20,7 @@ public class RandomGenerator {
         if (generator instanceof CollectionGenerator collectionGenerator) {
             setCollectionSize.accept(collectionGenerator);
         }
-        T generated = (T) generator.generate(type);
+        T generated = (T) generator.generate();
         objectStack.pop();
         return generated;
     }
@@ -42,8 +42,18 @@ public class RandomGenerator {
     }
 
     public <T> T generate(Type type, Type... genericTypes) {
-        Type parameterizedType = new ParameterizedTypeImpl(genericTypes,(Class<?>) type,null);
+        Type parameterizedType = new ParameterizedTypeImpl(genericTypes, (Class<?>) type, null);
         return generate(parameterizedType);
+    }
+
+    public <T> T generate(Type type, int size, Type... genericTypes) {
+        Type parameterizedType = new ParameterizedTypeImpl(genericTypes, (Class<?>) type, null);
+        return generate(parameterizedType, size);
+    }
+
+    public <T> T generate(Type type, int minSize, int maxSize, Type... genericTypes) {
+        Type parameterizedType = new ParameterizedTypeImpl(genericTypes, (Class<?>) type, null);
+        return generate(parameterizedType, minSize, maxSize);
     }
 
     /**

--- a/src/main/java/io/javarig/TypeEnum.java
+++ b/src/main/java/io/javarig/TypeEnum.java
@@ -30,16 +30,18 @@ public enum TypeEnum {
 
     final List<Type> values;
     final Generator generator;
+
     TypeEnum(List<Type> values, Generator generator) {
         this.values = values;
         this.generator = generator;
     }
 
     public static TypeEnum fromType(Type type) {
-        if (type instanceof ParameterizedType) type = ((ParameterizedType) type).getRawType();
-        Class<?> finalType = (Class<?>) type;
-        return Arrays.stream(TypeEnum.values())
-                .filter(typeEnum -> typeEnum.values.contains(finalType))
+        Type rawType = type;
+        if (type instanceof ParameterizedType) rawType = ((ParameterizedType) rawType).getRawType();
+        Class<?> finalType = (Class<?>) rawType;
+        TypeEnum typeEnum = Arrays.stream(TypeEnum.values())
+                .filter(tEnum -> tEnum.values.contains(finalType))
                 .findFirst()
                 .orElseGet(() -> {
                     try {
@@ -49,12 +51,21 @@ public enum TypeEnum {
                             return LIST;
                         if (finalType.isEnum())
                             return ENUM;
-                    } catch (Exception ignored) {}
+                    } catch (Exception ignored) {
+                    }
                     return OBJECT;
                 });
+        typeEnum.setType(type);
+        return typeEnum;
     }
 
-    public Generator generator(){
+    public Generator generator() {
         return this.generator;
+    }
+
+    public void setType(Type type) {
+        if (this.generator instanceof GenericTypeGenerator genericTypeGenerator) {
+            genericTypeGenerator.setType((ParameterizedType) type);
+        }
     }
 }

--- a/src/main/java/io/javarig/generator/BooleanGenerator.java
+++ b/src/main/java/io/javarig/generator/BooleanGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class BooleanGenerator implements Generator{
     @Override
-    public Boolean generate(Type type) {
+    public Boolean generate() {
         return random.nextBoolean();
     }
 }

--- a/src/main/java/io/javarig/generator/ByteArrayGenerator.java
+++ b/src/main/java/io/javarig/generator/ByteArrayGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class ByteArrayGenerator implements Generator{
     @Override
-    public Byte[] generate(Type type) {
+    public Byte[] generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/ByteGenerator.java
+++ b/src/main/java/io/javarig/generator/ByteGenerator.java
@@ -1,11 +1,9 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class ByteGenerator implements Generator {
 
     @Override
-    public Byte generate(Type type) {
+    public Byte generate() {
         byte[] bytes = new byte[1];
         random.nextBytes(bytes);
         return bytes[0];

--- a/src/main/java/io/javarig/generator/CharGenerator.java
+++ b/src/main/java/io/javarig/generator/CharGenerator.java
@@ -2,11 +2,9 @@ package io.javarig.generator;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
-import java.lang.reflect.Type;
-
 public class CharGenerator implements Generator {
     @Override
-    public Character generate(Type type) {
+    public Character generate() {
         return RandomStringUtils.randomAlphabetic(1).charAt(0);
     }
 }

--- a/src/main/java/io/javarig/generator/CollectionGenerator.java
+++ b/src/main/java/io/javarig/generator/CollectionGenerator.java
@@ -1,16 +1,18 @@
 package io.javarig.generator;
 
-import lombok.Getter;
-import lombok.Setter;
+public interface CollectionGenerator extends Generator{
+    default int getMaxSize(){
+        return 15;
+    }
 
-@Setter
-@Getter
-public abstract class CollectionGenerator implements Generator{
-    protected int maxSize = 15;
-    protected int minSize = 5;
+    default int getMinSize(){
+        return 5;
+    }
 
-    public void setSize(int size){
-        this.minSize = size;
-        this.maxSize = size;
+    void setMinSize(int minSize);
+    void setMaxSize(int maxSize);
+    default void setSize(int size){
+        this.setMinSize(size);
+        this.setMaxSize(size);
     }
 }

--- a/src/main/java/io/javarig/generator/DateGenerator.java
+++ b/src/main/java/io/javarig/generator/DateGenerator.java
@@ -1,11 +1,10 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
 import java.util.Date;
 
 public class DateGenerator implements Generator{
     @Override
-    public Date generate(Type type) {
+    public Date generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/DoubleGenerator.java
+++ b/src/main/java/io/javarig/generator/DoubleGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class DoubleGenerator implements Generator{
     @Override
-    public Double generate(Type type) {
+    public Double generate() {
         return random.nextDouble(0, Double.MAX_VALUE);
     }
 }

--- a/src/main/java/io/javarig/generator/EnumGenerator.java
+++ b/src/main/java/io/javarig/generator/EnumGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class EnumGenerator implements Generator {
     @Override
-    public Object generate(Type type) {
+    public Object generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/FloatGenerator.java
+++ b/src/main/java/io/javarig/generator/FloatGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class FloatGenerator implements Generator {
     @Override
-    public Float generate(Type type) {
+    public Float generate() {
         return random.nextFloat(0, Float.MAX_VALUE + 1);
     }
 }

--- a/src/main/java/io/javarig/generator/Generator.java
+++ b/src/main/java/io/javarig/generator/Generator.java
@@ -2,11 +2,10 @@ package io.javarig.generator;
 
 import io.javarig.RandomGenerator;
 
-import java.lang.reflect.Type;
 import java.util.Random;
 
 public interface Generator {
     Random random = new Random();
     RandomGenerator randomGenerator = new RandomGenerator();
-    Object generate(Type type);
+    Object generate();
 }

--- a/src/main/java/io/javarig/generator/Generator.java
+++ b/src/main/java/io/javarig/generator/Generator.java
@@ -1,9 +1,12 @@
 package io.javarig.generator;
 
+import io.javarig.RandomGenerator;
+
 import java.lang.reflect.Type;
 import java.util.Random;
 
 public interface Generator {
     Random random = new Random();
+    RandomGenerator randomGenerator = new RandomGenerator();
     Object generate(Type type);
 }

--- a/src/main/java/io/javarig/generator/GenericTypeGenerator.java
+++ b/src/main/java/io/javarig/generator/GenericTypeGenerator.java
@@ -1,0 +1,9 @@
+package io.javarig.generator;
+
+import java.lang.reflect.ParameterizedType;
+
+public interface GenericTypeGenerator extends Generator {
+    ParameterizedType getType();
+
+    void setType(ParameterizedType type);
+}

--- a/src/main/java/io/javarig/generator/InstantGenerator.java
+++ b/src/main/java/io/javarig/generator/InstantGenerator.java
@@ -1,11 +1,10 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
 import java.time.Instant;
 
 public class InstantGenerator implements Generator{
     @Override
-    public Instant generate(Type type) {
+    public Instant generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/IntegerGenerator.java
+++ b/src/main/java/io/javarig/generator/IntegerGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class IntegerGenerator implements Generator{
     @Override
-    public Integer generate(Type ignored) {
+    public Integer generate() {
         return random.nextInt(0, Integer.MAX_VALUE);
     }
 }

--- a/src/main/java/io/javarig/generator/ListGenerator.java
+++ b/src/main/java/io/javarig/generator/ListGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class ListGenerator implements Generator{
     @Override
-    public Object generate(Type type) {
+    public Object generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/LocalDateGenerator.java
+++ b/src/main/java/io/javarig/generator/LocalDateGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class LocalDateGenerator implements Generator{
     @Override
-    public Object generate(Type type) {
+    public Object generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/LongGenerator.java
+++ b/src/main/java/io/javarig/generator/LongGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class LongGenerator implements Generator{
     @Override
-    public Long generate(Type type) {
+    public Long generate() {
         return random.nextLong(0, Long.MAX_VALUE);
     }
 }

--- a/src/main/java/io/javarig/generator/MapGenerator.java
+++ b/src/main/java/io/javarig/generator/MapGenerator.java
@@ -1,15 +1,23 @@
 package io.javarig.generator;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MapGenerator extends CollectionGenerator {
+@Setter
+@Getter
+public class MapGenerator implements GenericTypeGenerator, CollectionGenerator {
+    private int minSize = 5;
+    private int maxSize = 15;
+    private ParameterizedType type;
     @Override
-    public Map<Object,Object> generate(Type type) {
-        int size = random.nextInt(minSize, maxSize);
-        ParameterizedType parameterizedType = (ParameterizedType) type;
+    public Map<Object,Object> generate() {
+        int size = random.nextInt(getMinSize(), getMaxSize());
+        ParameterizedType parameterizedType = getType();
         Type keyType = parameterizedType.getActualTypeArguments()[0];
         Type valueType = parameterizedType.getActualTypeArguments()[1];
         Map<Object, Object> resultedMap = new HashMap<>();

--- a/src/main/java/io/javarig/generator/MapGenerator.java
+++ b/src/main/java/io/javarig/generator/MapGenerator.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class MapGenerator extends CollectionGenerator {
     @Override
-    public Object generate(Type type) {
+    public Map<Object,Object> generate(Type type) {
         int size = random.nextInt(minSize, maxSize);
         ParameterizedType parameterizedType = (ParameterizedType) type;
         Type keyType = parameterizedType.getActualTypeArguments()[0];

--- a/src/main/java/io/javarig/generator/MapGenerator.java
+++ b/src/main/java/io/javarig/generator/MapGenerator.java
@@ -1,10 +1,25 @@
 package io.javarig.generator;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
-public class MapGenerator implements Generator{
+public class MapGenerator extends CollectionGenerator {
     @Override
     public Object generate(Type type) {
-        return null;
+        int size = random.nextInt(minSize, maxSize);
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        Type keyType = parameterizedType.getActualTypeArguments()[0];
+        Type valueType = parameterizedType.getActualTypeArguments()[1];
+        Map<Object, Object> resultedMap = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            try {
+                resultedMap.put(randomGenerator.generate(Class.forName(keyType.getTypeName())),
+                        randomGenerator.generate(Class.forName(valueType.getTypeName())));
+            } catch (Exception ignore) {
+            }
+        }
+        return resultedMap;
     }
 }

--- a/src/main/java/io/javarig/generator/ObjectGenerator.java
+++ b/src/main/java/io/javarig/generator/ObjectGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
-public class ObjectGenerator implements Generator{
+public class ObjectGenerator implements Generator {
     @Override
-    public Object generate(Type type) {
+    public Object generate() {
         return null;
     }
 }

--- a/src/main/java/io/javarig/generator/ShortGenerator.java
+++ b/src/main/java/io/javarig/generator/ShortGenerator.java
@@ -1,10 +1,8 @@
 package io.javarig.generator;
 
-import java.lang.reflect.Type;
-
 public class ShortGenerator implements Generator {
     @Override
-    public Short generate(Type type) {
+    public Short generate() {
         return (short) random.nextInt(0, Short.MAX_VALUE + 1);
     }
 }

--- a/src/main/java/io/javarig/generator/StringGenerator.java
+++ b/src/main/java/io/javarig/generator/StringGenerator.java
@@ -1,12 +1,16 @@
 package io.javarig.generator;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.RandomStringUtils;
 
-import java.lang.reflect.Type;
-
-public class StringGenerator extends CollectionGenerator{
+@Setter
+@Getter
+public class StringGenerator implements CollectionGenerator {
+    private int minSize = 5;
+    private int maxSize = 15;
     @Override
-    public String generate(Type type) {
-        return RandomStringUtils.randomAlphanumeric(minSize,maxSize);
+    public String generate() {
+        return RandomStringUtils.randomAlphanumeric(this.getMinSize(), this.getMaxSize());
     }
 }

--- a/src/test/java/io/javarig/JavaRIGTests.java
+++ b/src/test/java/io/javarig/JavaRIGTests.java
@@ -1,15 +1,19 @@
 package io.javarig;
 
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.*;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @Slf4j
 public class JavaRIGTests {
     private RandomGenerator randomGenerator;
+
     @BeforeEach
     public void setUp() {
         randomGenerator = new RandomGenerator();
@@ -18,7 +22,7 @@ public class JavaRIGTests {
     @Test
     public void shouldGenerateString() {
         Object generated = randomGenerator.generate(String.class);
-        log.info("shouldGenerateString : {}",generated);
+        log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
     }
@@ -26,8 +30,8 @@ public class JavaRIGTests {
     @Test
     public void shouldGenerateStringWithExactSize() {
         int size = 20;
-        Object generated = randomGenerator.generate(String.class,size);
-        log.info("shouldGenerateString : {}",generated);
+        Object generated = randomGenerator.generate(String.class, size);
+        log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
         assertThat(generated).asString().hasSize(size);
@@ -37,74 +41,99 @@ public class JavaRIGTests {
     public void shouldGenerateStringBetweenMinAndMaxSize() {
         int minSize = 20;
         int maxSize = 40;
-        Object generated = randomGenerator.generate(String.class,minSize,maxSize);
-        log.info("shouldGenerateString : {}",generated);
+        Object generated = randomGenerator.generate(String.class, minSize, maxSize);
+        log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
-        assertThat(generated).asString().hasSizeBetween(minSize,maxSize);
+        assertThat(generated).asString().hasSizeBetween(minSize, maxSize);
     }
 
     @Test
-    public void shouldGenerateInteger(){
+    public void shouldGenerateInteger() {
         Object generated = randomGenerator.generate(Integer.class);
-        log.info("shouldGenerateInteger : {}",generated);
+        log.info("shouldGenerateInteger : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Integer.class);
     }
 
     @Test
-    public void shouldReturnBoolean(){
+    public void shouldReturnBoolean() {
         Object generated = randomGenerator.generate(Boolean.class);
-        log.info("shouldReturnBoolean : {}",generated);
+        log.info("shouldReturnBoolean : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Boolean.class);
     }
 
     @Test
-    public void shouldReturnFloat(){
+    public void shouldReturnFloat() {
         Object generated = randomGenerator.generate(Float.class);
-        log.info("shouldReturnFloat : {}",generated);
+        log.info("shouldReturnFloat : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Float.class);
     }
 
     @Test
-    public void shouldReturnLong(){
+    public void shouldReturnLong() {
         Object generated = randomGenerator.generate(Long.class);
-        log.info("shouldReturnLong : {}",generated);
+        log.info("shouldReturnLong : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Long.class);
     }
 
     @Test
-    public void shouldReturnShort(){
+    public void shouldReturnShort() {
         Object generated = randomGenerator.generate(Short.class);
-        log.info("shouldReturnShort : {}",generated);
+        log.info("shouldReturnShort : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Short.class);
     }
 
     @Test
-    public void shouldReturnChar(){
+    public void shouldReturnChar() {
         Object generated = randomGenerator.generate(Character.class);
-        log.info("shouldReturnChar : {}",generated);
+        log.info("shouldReturnChar : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Character.class);
     }
 
     @Test
-    public void shouldReturnDouble(){
+    public void shouldReturnDouble() {
         Object generated = randomGenerator.generate(Double.class);
-        log.info("shouldReturnDouble : {}",generated);
+        log.info("shouldReturnDouble : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Double.class);
     }
 
     @Test
-    public void shouldReturnByte(){
+    public void shouldReturnByte() {
         Object generated = randomGenerator.generate(Byte.class);
-        log.info("shouldReturnByte : {}",generated);
+        log.info("shouldReturnByte : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Byte.class);
+    }
+
+    @Test
+    public void shouldReturnMap() {
+        //given
+            Class<?> keyType = String.class;
+            Class<?> valueType = Integer.class;
+        //when
+            Object generated = randomGenerator.generate(Map.class, keyType, valueType);
+        //then
+            log.info("shouldReturnMap : {}", generated);
+            assertThat(generated).isNotNull();
+            assertThat(generated).isInstanceOf(Map.class);
+
+            //asserting keys type
+            assertThat(generated)
+                    .asInstanceOf(InstanceOfAssertFactories.MAP)
+                    .extracting((map) -> map.keySet().toArray()[0])
+                    .isInstanceOf(keyType);
+
+            //asserting values type
+            assertThat(generated)
+                    .asInstanceOf(InstanceOfAssertFactories.MAP)
+                    .extracting((map) -> map.values().toArray()[0])
+                    .isInstanceOf(valueType);
     }
 }

--- a/src/test/java/io/javarig/TestClass.java
+++ b/src/test/java/io/javarig/TestClass.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import java.lang.reflect.Type;
+import java.util.*;
 
 /**
  * this is the test class for which we will be trying to generate random objects
@@ -16,9 +19,16 @@ import lombok.ToString;
 @Setter
 @Getter
 @ToString
+@Slf4j
 public class TestClass {
     //    private TestClass2 testClass2;
-    private Object m;
+    public static void main(String[] args) {
+        Map<String,String> test ;
+
+        Type type = new ParameterizedTypeImpl(new Type[]{String.class,String.class},Map.class,null);
+        log.info(type.getTypeName());
+    }
+    private Map<String,String> m;
 //    private List<String> s;
 //    private TestEnum e;
 }


### PR DESCRIPTION
For the ParametrizedTypeImpl, I created my own implementation because I needed an instance of ParametrizedType to hold generic types and I couldn't use sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.