### PR TITLE
Support generic objects

### DIFF
--- a/src/main/java/io/javarig/RandomInstanceGenerator.java
+++ b/src/main/java/io/javarig/RandomInstanceGenerator.java
@@ -3,13 +3,11 @@ package io.javarig;
 import io.javarig.exception.InstanceGenerationException;
 import io.javarig.exception.NestedObjectRecursionException;
 import io.javarig.generator.CollectionGenerator;
-import io.javarig.generator.ObjectGenerator;
 import io.javarig.generator.TypeGenerator;
 import lombok.NonNull;
 import org.apache.commons.lang3.Validate;
 
 import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.Stack;
 import java.util.function.Consumer;
 
@@ -98,16 +96,6 @@ public class RandomInstanceGenerator {
         return generate(parameterizedType);
     }
 
-    public <T> T generate(
-            @NonNull Type objectType,
-            @NonNull Map<String,Type> genericTypes
-    ) throws InstanceGenerationException {
-        return generate(objectType, generator -> {
-            if(generator instanceof ObjectGenerator objectGenerator){
-                objectGenerator.setGenericTypes(genericTypes);
-            }
-        });
-    }
 
     /**
      * generate a random instance of a generic collection with a fixed size

--- a/src/main/java/io/javarig/RandomInstanceGenerator.java
+++ b/src/main/java/io/javarig/RandomInstanceGenerator.java
@@ -17,11 +17,11 @@ public class RandomInstanceGenerator {
     private final TypeGeneratorFactory typeGeneratorFactory = new TypeGeneratorFactory();
 
     @SuppressWarnings({"unchecked"})
-    private synchronized <T> T generate(Type type, Consumer<TypeGenerator> setUpGenerator) throws InstanceGenerationException {
+    private synchronized <T> T generate(Type type, Consumer<TypeGenerator> generatorSetup) throws InstanceGenerationException {
         checkForRecursion(type);
         objectStack.push(type);
         TypeGenerator generator = typeGeneratorFactory.getGenerator(type, this);
-        setUpGenerator.accept(generator);
+        generatorSetup.accept(generator);
         T generated = (T) generator.generate();
         objectStack.pop();
         return generated;

--- a/src/main/java/io/javarig/generator/ObjectGenerator.java
+++ b/src/main/java/io/javarig/generator/ObjectGenerator.java
@@ -81,7 +81,7 @@ public class ObjectGenerator extends TypeGenerator {
     private void generateField(Object generatedObject, Method setter, Field field) throws InstanceGenerationException {
         Type type = field.getGenericType();
         if(type instanceof ParameterizedType parameterizedType){
-            type = setTypeArguments(parameterizedType);
+            type = resolveTypeArguments(parameterizedType);
         }
         Object generatedField = getRandomInstanceGenerator().generate(GenericTypes.resolve(type, genericTypesMap));
         try {
@@ -95,7 +95,7 @@ public class ObjectGenerator extends TypeGenerator {
         }
     }
 
-    private Type setTypeArguments(Type type) {
+    private Type resolveTypeArguments(Type type) {
         ParameterizedType parameterizedType = (ParameterizedType) type;
         List<Type> typeArguments = Arrays.stream(parameterizedType.getActualTypeArguments())
                 .map((typeArgument -> GenericTypes.resolve(typeArgument, genericTypesMap)))

--- a/src/main/java/io/javarig/generator/TypeGenerator.java
+++ b/src/main/java/io/javarig/generator/TypeGenerator.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -19,7 +21,6 @@ public abstract class TypeGenerator {
     private final Random random = new Random();
     private final Type type;
     private final RandomInstanceGenerator randomInstanceGenerator;
-
     /**
      * generates a random object, its type is known from the extending class
      */

--- a/src/main/java/io/javarig/generator/TypeGenerator.java
+++ b/src/main/java/io/javarig/generator/TypeGenerator.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 
 /**

--- a/src/main/java/io/javarig/util/GenericTypes.java
+++ b/src/main/java/io/javarig/util/GenericTypes.java
@@ -1,0 +1,13 @@
+package io.javarig.util;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class GenericTypes {
+    public static Type resolve(Type type, Map<String, Type> genericTypesMap){
+        if(genericTypesMap.containsKey(type.getTypeName())){
+            return genericTypesMap.get(type.getTypeName());
+        }
+        return type;
+    }
+}

--- a/src/test/java/io/javarig/generation/ObjectGenerationTest.java
+++ b/src/test/java/io/javarig/generation/ObjectGenerationTest.java
@@ -12,9 +12,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -198,8 +195,7 @@ public class ObjectGenerationTest {
     @ValueSource(classes = {String.class, Integer.class, Double.class, BaseClass.class})
     public void shouldGenerateAGenericClass(Type genericType) {
         //given
-        Map<String, Type> genericTypes = Map.of("T", genericType);
-        Object generatedObject = randomInstanceGenerator.generate(GenericTestClass.class, genericTypes);
+        Object generatedObject = randomInstanceGenerator.generate(GenericTestClass.class, genericType);
         // then
         assertThat(generatedObject)
                 .isNotNull()
@@ -214,4 +210,32 @@ public class ObjectGenerationTest {
                 .isInstanceOf((Class<?>) genericType);
     }
 
+    @Test
+    public void shouldGenerateAGenericClassWithRightOrderTypes() {
+        //given
+        Class<String> classParam1 = String.class;
+        Class<Integer> classParam2 = Integer.class;
+        Object generatedObject = randomInstanceGenerator.generate(GenericTestClass2.class, classParam1, classParam2);
+        // then
+        assertThat(generatedObject)
+                .isNotNull()
+                .isInstanceOf(GenericTestClass2.class);
+
+        GenericTestClass2<String, Integer> genericTestClass2 = (GenericTestClass2) generatedObject;
+        assertThat(genericTestClass2)
+                .extracting(GenericTestClass2::getGenericClass3)
+                .isNotNull()
+                .isInstanceOf(GenericTestClass3.class)
+                .extracting(GenericTestClass3::getT)
+                .isNotNull()
+                .isInstanceOf(classParam2);
+
+        assertThat(genericTestClass2)
+                .extracting(GenericTestClass2::getGenericClass3)
+                .isNotNull()
+                .isInstanceOf(GenericTestClass3.class)
+                .extracting(GenericTestClass3::getK)
+                .isNotNull()
+                .isInstanceOf(classParam1);
+    }
 }

--- a/src/test/java/io/javarig/generation/ObjectGenerationTest.java
+++ b/src/test/java/io/javarig/generation/ObjectGenerationTest.java
@@ -7,10 +7,14 @@ import io.javarig.testclasses.*;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -190,10 +194,10 @@ public class ObjectGenerationTest {
                 .isInstanceOf(Float.class);
     }
 
-    @Test
-    public void shouldGenerateAGenericClass() {
+    @ParameterizedTest
+    @ValueSource(classes = {String.class, Integer.class, Double.class, BaseClass.class})
+    public void shouldGenerateAGenericClass(Type genericType) {
         //given
-        Type genericType = Integer.class;
         Map<String, Type> genericTypes = Map.of("T", genericType);
         Object generatedObject = randomInstanceGenerator.generate(GenericTestClass.class, genericTypes);
         // then

--- a/src/test/java/io/javarig/generation/ObjectGenerationTest.java
+++ b/src/test/java/io/javarig/generation/ObjectGenerationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -187,6 +188,26 @@ public class ObjectGenerationTest {
                 .extracting(BaseClass::getInheritedField)
                 .isNotNull()
                 .isInstanceOf(Float.class);
+    }
+
+    @Test
+    public void shouldGenerateAGenericClass() {
+        //given
+        Type genericType = Integer.class;
+        Map<String, Type> genericTypes = Map.of("T", genericType);
+        Object generatedObject = randomInstanceGenerator.generate(GenericTestClass.class, genericTypes);
+        // then
+        assertThat(generatedObject)
+                .isNotNull()
+                .isInstanceOf(GenericTestClass.class);
+        GenericTestClass<String> genericTestClass = (GenericTestClass) generatedObject;
+        assertThat(genericTestClass)
+                .extracting(GenericTestClass::getList)
+                .asList()
+                .isNotNull()
+                .hasSizeBetween(CollectionGenerator.DEFAULT_MIN_SIZE_INCLUSIVE, CollectionGenerator.DEFAULT_MAX_SIZE_EXCLUSIVE)// could be better if we had access to collectionGenerator defaultMin defaultMax size as public static fields
+                .element(0)
+                .isInstanceOf((Class<?>) genericType);
     }
 
 }

--- a/src/test/java/io/javarig/testclasses/BaseClass.java
+++ b/src/test/java/io/javarig/testclasses/BaseClass.java
@@ -3,10 +3,12 @@ package io.javarig.testclasses;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @NoArgsConstructor
 @Getter
 @Setter
+@ToString
 public class BaseClass extends SuperClass{
     int baseField;
 }

--- a/src/test/java/io/javarig/testclasses/GenericTestClass.java
+++ b/src/test/java/io/javarig/testclasses/GenericTestClass.java
@@ -3,12 +3,14 @@ package io.javarig.testclasses;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.List;
 
 @NoArgsConstructor
 @Getter
 @Setter
+@ToString
 public class GenericTestClass<T> {
     private List<T> list;
 }

--- a/src/test/java/io/javarig/testclasses/GenericTestClass.java
+++ b/src/test/java/io/javarig/testclasses/GenericTestClass.java
@@ -1,0 +1,14 @@
+package io.javarig.testclasses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class GenericTestClass<T> {
+    private List<T> list;
+}

--- a/src/test/java/io/javarig/testclasses/GenericTestClass2.java
+++ b/src/test/java/io/javarig/testclasses/GenericTestClass2.java
@@ -1,0 +1,14 @@
+package io.javarig.testclasses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class GenericTestClass2<T,K> {
+    private GenericTestClass3<K,T> genericClass3;
+}

--- a/src/test/java/io/javarig/testclasses/GenericTestClass3.java
+++ b/src/test/java/io/javarig/testclasses/GenericTestClass3.java
@@ -1,0 +1,15 @@
+package io.javarig.testclasses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class GenericTestClass3<T,K> {
+    private T t;
+    private K k;
+}


### PR DESCRIPTION
You can generate instances of a generic class by passing an array of types `Type...` representing the type parameters. For example, if you have a class `class Car<T>` and you want the generic value to be String, you can do `generate(Car.class, String.class);`.