### PR TITLE
Fix oneTimeConfig overriding all general configs

### DIFF
--- a/src/main/java/io/javarig/RandomInstanceGenerator.java
+++ b/src/main/java/io/javarig/RandomInstanceGenerator.java
@@ -4,10 +4,11 @@ import io.javarig.config.Configuration;
 import io.javarig.exception.InstanceGenerationException;
 import io.javarig.exception.NestedObjectRecursionException;
 import io.javarig.generator.TypeGenerator;
+import io.javarig.util.Utils;
+import io.javarig.util.Validators;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-
 
 import java.lang.reflect.Type;
 import java.util.Stack;
@@ -36,34 +37,15 @@ public class RandomInstanceGenerator {
      *                                     default constructor , setter cannot be
      *                                     invoked ... )
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public <T> T generate(@NonNull Type objectType) throws InstanceGenerationException {
         checkForRecursion(objectType);
         objectStack.push(objectType);
         TypeGenerator generator = typeGeneratorFactory.getGenerator(objectType, this);
         T generated = (T) generator.generate();
         objectStack.pop();
+        clearOneTimeConfig();
         return generated;
-    }
-
-    /**
-     * generate a random instance for a collection, with a one time configuration
-     *
-     * @param objectType    type of the object
-     * @param oneTimeConfig a configuration for the generator that gets applied one
-     *                      time and doesn't overide the general configuration
-     *                      provided at the creation
-     * @return the generated object
-     * @throws InstanceGenerationException if the instance cannot be generated for
-     *                                     some reason (class doesn't have a default
-     *                                     constructor , class have a non-public
-     *                                     default constructor , setter cannot be
-     *                                     invoked ... )
-     */
-    public <T> T generate(@NonNull Type objectType,
-            Configuration oneTimeConfig
-    ) throws InstanceGenerationException {
-        return generateWithOneTimeConfig(objectType, oneTimeConfig);
     }
 
     /**
@@ -80,46 +62,16 @@ public class RandomInstanceGenerator {
      */
     public <T> T generate(
             @NonNull Type objectType,
-            @NonNull Type... genericTypes
-    ) throws InstanceGenerationException {
+            @NonNull Type... genericTypes) throws InstanceGenerationException {
         Type parameterizedType = new ParameterizedTypeImpl(genericTypes, (Class<?>) objectType);
         return generate(parameterizedType);
     }
 
     /**
-     * generate a random instance of a generic collection with a fixed size
-     *
-     * @param objectType    type of the object
-     * @param oneTimeConfig a configuration for the generator that gets applied one
-     *                      time and doesn't overide the general configuration
-     *                      provided at the creation
-     * @param genericTypes  types of generic parameters
-     * @return the generated object
-     * @throws InstanceGenerationException if the instance cannot be generated for
-     *                                     some reason (class doesn't have
-     *                                     a default constructor , class have a
-     *                                     non-public default constructor , setter
-     *                                     cannot be invoked ... )
-     */
-    public <T> T generate(
-            @NonNull Type objectType,
-            Configuration oneTimeConfig,
-            @NonNull Type... genericTypes
-    ) throws InstanceGenerationException {
-        Type parameterizedType = new ParameterizedTypeImpl(genericTypes, (Class<?>) objectType);
-        return generate(parameterizedType, oneTimeConfig);
-    }
-
-    private <T> T generateWithOneTimeConfig(@NonNull Type objectType, Configuration oneTimeConfig) {
-        this.oneTimeConfig = oneTimeConfig;
-        T generatedObject = generate(objectType);
-        this.oneTimeConfig = null;
-        return generatedObject;
-    }
-
-    /**
-     * check if type exists in objectStack, if so then object can't be generated because there is recursion
-     * in this object's fields (there is a field that it's instantiation depends on owner object)
+     * check if type exists in objectStack, if so then object can't be generated
+     * because there is recursion
+     * in this object's fields (there is a field that it's instantiation depends on
+     * owner object)
      * so NestedObjectRecursion is thrown
      *
      * @param type - a type to search for in the stack
@@ -130,6 +82,33 @@ public class RandomInstanceGenerator {
         }
     }
 
+    private void clearOneTimeConfig() {
+        if (objectStack.empty()) {
+            this.oneTimeConfig = null;
+        }
+    }
 
+    public RandomInstanceGenerator withSize(int size) {
+        Validators.validateSize(size);
+        this.oneTimeConfig = generalConfig.withMaxSizeExclusive(size + 1).withMinSizeInclusive(size);
+        return this;
+    }
 
+    public RandomInstanceGenerator withSize(int minSizeInclusive, int maxSizeExclusive) {
+        Validators.validateSize(minSizeInclusive, maxSizeExclusive);
+        this.oneTimeConfig = generalConfig.withMaxSizeExclusive(maxSizeExclusive)
+                .withMinSizeInclusive(minSizeInclusive);
+        return this;
+    }
+
+    public RandomInstanceGenerator withRegexPattern(String regexPattern) {
+        Validators.validateRegexPattern(Utils.removeUnsupportedRegexCharacters(regexPattern));
+        this.oneTimeConfig = generalConfig.withRegexPattern(regexPattern);
+        return this;
+    }
+
+    public RandomInstanceGenerator withOneTimeConfig(Configuration oneTimeConfig) {
+        this.oneTimeConfig = oneTimeConfig;
+        return this;
+    }
 }

--- a/src/main/java/io/javarig/RandomInstanceGenerator.java
+++ b/src/main/java/io/javarig/RandomInstanceGenerator.java
@@ -26,6 +26,11 @@ public class RandomInstanceGenerator {
         this.generalConfig = Configuration.builder().build();
     }
 
+    public RandomInstanceGenerator(Configuration generalConfig, Configuration oneTimeConfig) {
+        this.generalConfig = generalConfig;
+        this.oneTimeConfig = oneTimeConfig;
+    }
+
     /**
      * generate a random instance of the given type
      * 
@@ -90,25 +95,23 @@ public class RandomInstanceGenerator {
 
     public RandomInstanceGenerator withSize(int size) {
         Validators.validateSize(size);
-        this.oneTimeConfig = generalConfig.withMaxSizeExclusive(size + 1).withMinSizeInclusive(size);
-        return this;
+        Configuration oneTimeConfig = generalConfig.withMaxSizeExclusive(size + 1).withMinSizeInclusive(size);
+        return new RandomInstanceGenerator(generalConfig, oneTimeConfig);
     }
 
     public RandomInstanceGenerator withSize(int minSizeInclusive, int maxSizeExclusive) {
         Validators.validateSize(minSizeInclusive, maxSizeExclusive);
-        this.oneTimeConfig = generalConfig.withMaxSizeExclusive(maxSizeExclusive)
+        Configuration oneTimeConfig = generalConfig.withMaxSizeExclusive(maxSizeExclusive)
                 .withMinSizeInclusive(minSizeInclusive);
-        return this;
+        return new RandomInstanceGenerator(generalConfig, oneTimeConfig);
     }
 
     public RandomInstanceGenerator withRegexPattern(String regexPattern) {
         Validators.validateRegexPattern(Utils.removeUnsupportedRegexCharacters(regexPattern));
-        this.oneTimeConfig = generalConfig.withRegexPattern(regexPattern);
-        return this;
+        return new RandomInstanceGenerator(generalConfig, generalConfig.withRegexPattern(regexPattern));
     }
 
     public RandomInstanceGenerator withOneTimeConfig(Configuration oneTimeConfig) {
-        this.oneTimeConfig = oneTimeConfig;
-        return this;
+        return new RandomInstanceGenerator(generalConfig, oneTimeConfig);
     }
 }

--- a/src/main/java/io/javarig/config/Configuration.java
+++ b/src/main/java/io/javarig/config/Configuration.java
@@ -1,15 +1,12 @@
 package io.javarig.config;
 
-import com.mifmif.common.regex.Generex;
-import org.apache.commons.lang3.Validate;
-
 import lombok.Builder;
 import lombok.Getter;
-
-import static io.javarig.util.Utils.removeUnsupportedRegexCharacters;
+import lombok.With;
 
 @Getter
 @Builder
+@With
 public class Configuration {
 
     @Builder.Default
@@ -18,43 +15,6 @@ public class Configuration {
     private int minSizeInclusive = DefaultConfigValues.DEFAULT_MIN_SIZE_INCLUSIVE;
     @Builder.Default
     private String regexPattern = DefaultConfigValues.DEFAULT_REGEX_PATTERN;
-
-    public static Configuration withSize(int size) {
-        validateSize(size);
-        return Configuration.builder()
-                .maxSizeExclusive(size + 1)
-                .minSizeInclusive(size)
-                .build();
-    }
-
-    public static Configuration withSize(int minSizeInclusive, int maxSizeExclusive) {
-        validateSize(minSizeInclusive, maxSizeExclusive);
-        return Configuration.builder()
-                .maxSizeExclusive(maxSizeExclusive)
-                .minSizeInclusive(minSizeInclusive)
-                .build();
-    }
-
-    public static Configuration withRegexPattern(String regexPattern) {
-        validateRegexPattern(removeUnsupportedRegexCharacters(regexPattern));
-        return Configuration.builder()
-                .regexPattern(regexPattern)
-                .build();
-    }
-
-    // validations
-    private static void validateSize(int minSizeInclusive, int maxSizeExclusive) {
-        Validate.isTrue(maxSizeExclusive > minSizeInclusive, "Start value must be smaller than end value.");
-        Validate.isTrue(minSizeInclusive >= 0, "Both range values must be non-negative.");
-    }
-
-    private static void validateSize(int size) {
-        Validate.isTrue(size >= 0, "Size must be non-negative.");
-    }
-
-    private static void validateRegexPattern(String regexPattern) {
-        Validate.isTrue(Generex.isValidPattern(regexPattern), "regex pattern not valid (or not supported).");
-    }
     // todo should override the build method to validate before building
 
 }

--- a/src/main/java/io/javarig/util/Validators.java
+++ b/src/main/java/io/javarig/util/Validators.java
@@ -1,0 +1,21 @@
+package io.javarig.util;
+
+import org.apache.commons.lang3.Validate;
+
+import com.mifmif.common.regex.Generex;
+
+public class Validators {
+
+    public static void validateSize(int minSizeInclusive, int maxSizeExclusive) {
+        Validate.isTrue(maxSizeExclusive > minSizeInclusive, "Start value must be smaller than end value.");
+        Validate.isTrue(minSizeInclusive >= 0, "Both range values must be non-negative.");
+    }
+
+    public static void validateSize(int size) {
+        Validate.isTrue(size >= 0, "Size must be non-negative.");
+    }
+
+    public static void validateRegexPattern(String regexPattern) {
+        Validate.isTrue(Generex.isValidPattern(regexPattern), "regex pattern not valid (or not supported).");
+    }
+}

--- a/src/test/java/io/javarig/config/ConfigurationTest.java
+++ b/src/test/java/io/javarig/config/ConfigurationTest.java
@@ -1,0 +1,118 @@
+package io.javarig.config;
+
+
+import io.javarig.RandomInstanceGenerator;
+import io.javarig.testclasses.ConfigurationTestClass;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import org.junit.jupiter.api.Test;
+
+
+@Slf4j
+public class ConfigurationTest {
+
+    @Test
+    public void shouldGenerateAnObjectRespectingTheGivenConfig() { 
+        // Given
+        Class<?> type = ConfigurationTestClass.class;
+        Configuration configuration = Configuration.builder()
+            .maxSizeExclusive(15)
+            .minSizeInclusive(5)
+            .regexPattern("abc+")
+            .build();
+        RandomInstanceGenerator generator = new RandomInstanceGenerator(configuration);
+        // When
+        Object generatedObject = generator.generate(type);
+        log.info("shouldGenerateAnObjectRespectingTheGivenConfig : {}", generatedObject);
+        // Then
+        assertThat(generatedObject).isInstanceOf(type);
+        // pattern config 
+        assertThat(generatedObject).extracting("s")
+            .asString()
+            .hasSizeBetween(configuration.getMinSizeInclusive(), configuration.getMaxSizeExclusive() - 1)
+            .matches(configuration.getRegexPattern());
+        // pattern config 
+        assertThat(generatedObject).extracting("l")
+            .asList()
+            .hasSizeBetween(configuration.getMinSizeInclusive(), configuration.getMaxSizeExclusive() - 1);
+        // other configs
+    }
+
+    @Test
+    public void shouldProrioritizeWithSizeConfigOverGeneralConfig() { 
+        // Given
+        Class<?> type = String.class;
+        Integer generalMinSize = 5;
+        Integer generalMaxSize = 10;
+        Configuration configuration = Configuration.builder()
+            .maxSizeExclusive(generalMaxSize)
+            .minSizeInclusive(generalMinSize)
+            .regexPattern("abc+")
+            .build();
+        
+        RandomInstanceGenerator generator = new RandomInstanceGenerator(configuration);
+        Integer newMinSize = generalMaxSize + 2;
+        Integer newMaxSize = newMinSize + 5;
+        // When
+        Object generatedObject = generator.withSize(newMinSize, newMaxSize).generate(type);
+        log.info("shouldProrioritizeWithSizeConfigOverGeneralConfig : {}", generatedObject);
+        // Then
+        assertThat(generatedObject).isInstanceOf(type);
+        assertThat(generatedObject)
+            .asString()
+            .matches(configuration.getRegexPattern())
+            .hasSizeBetween(newMinSize, newMaxSize - 1);
+    }
+
+    @Test
+    public void shouldProrioritizeWithRegexPatternConfigOverGeneralConfig() { 
+        // Given
+        Class<?> type = String.class;
+        String generalRegexPattern = "abc+";
+        Configuration configuration = Configuration.builder()
+            .maxSizeExclusive(10)
+            .minSizeInclusive(5)
+            .regexPattern(generalRegexPattern)
+            .build();
+        RandomInstanceGenerator generator = new RandomInstanceGenerator(configuration);
+        String newRegexPattern = "test+";
+        // When
+        Object generatedObject = generator.withRegexPattern(newRegexPattern).generate(type);
+        log.info("shouldProrioritizeWithRegexPatternConfigOverGeneralConfig : {}", generatedObject);
+        // Then
+        assertThat(generatedObject).isInstanceOf(type);
+        assertThat(generatedObject)
+            .asString()
+            .matches(newRegexPattern)
+            .hasSizeBetween(configuration.getMinSizeInclusive(), configuration.getMaxSizeExclusive() - 1);
+    }
+
+    @Test
+    public void shouldProrioritizeWithOneTimeConfigOverGeneralConfig() { 
+        // Given
+        Class<?> type = String.class;
+        String generalRegexPattern = "abc+";
+        Configuration configuration = Configuration.builder()
+            .maxSizeExclusive(10)
+            .minSizeInclusive(5)
+            .regexPattern(generalRegexPattern)
+            .build();
+        Configuration oneTimeConfig = Configuration.builder()
+            .maxSizeExclusive(20)
+            .minSizeInclusive(11)
+            .build();
+        RandomInstanceGenerator generator = new RandomInstanceGenerator(configuration);
+        // When
+        Object generatedObject = generator.withOneTimeConfig(oneTimeConfig).generate(type);
+        log.info("shouldProrioritizeWithRegexPatternConfigOverGeneralConfig : {}", generatedObject);
+        // Then
+        assertThat(generatedObject).isInstanceOf(type);
+        assertThat(generatedObject)
+            .asString()
+            .matches(oneTimeConfig.getRegexPattern())
+            .hasSizeBetween(oneTimeConfig.getMinSizeInclusive(), oneTimeConfig.getMaxSizeExclusive() - 1);
+    }
+}

--- a/src/test/java/io/javarig/generator/ArrayGenerationTest.java
+++ b/src/test/java/io/javarig/generator/ArrayGenerationTest.java
@@ -1,7 +1,6 @@
 package io.javarig.generator;
 
 import io.javarig.RandomInstanceGenerator;
-import io.javarig.config.Configuration;
 import io.javarig.testclasses.TestClass;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +33,7 @@ public class ArrayGenerationTest {
     @Test
     public void shouldReturnWrapperArrayWithExactSize() {
         int size = 20;
-        Object generated = randomInstanceGenerator.generate(Double[].class, Configuration.withSize(size));
+        Object generated = randomInstanceGenerator.withSize(size).generate(Double[].class);
         log.info("shouldReturnArrayWithExactSize : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(Double[].class);
@@ -44,7 +43,7 @@ public class ArrayGenerationTest {
     @Test
     public void shouldReturnPrimitiveArrayWithExactSize() {
         int size = 20;
-        Object generated = randomInstanceGenerator.generate(double[].class, Configuration.withSize(size));
+        Object generated = randomInstanceGenerator.withSize(size).generate(double[].class);
         log.info("shouldReturnArrayWithExactSize : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(double[].class);
@@ -55,7 +54,7 @@ public class ArrayGenerationTest {
     public void shouldReturnArrayWithSizeBetween() {
         int minSize = 20;
         int maxSize = 40;
-        Object generated = randomInstanceGenerator.generate(String[].class, Configuration.withSize(minSize, maxSize));
+        Object generated = randomInstanceGenerator.withSize(minSize, maxSize).generate(String[].class);
         log.info("shouldReturnArrayWithSizeBetween : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String[].class);
@@ -73,7 +72,7 @@ public class ArrayGenerationTest {
     @Test
     public void shouldReturnTestClassArrayWithExactSize() {
         int size = 22;
-        Object generated = randomInstanceGenerator.generate(TestClass[].class, Configuration.withSize(size));
+        Object generated = randomInstanceGenerator.withSize(size).generate(TestClass[].class);
         log.info("shouldReturnTestClassArrayWithExactSize {} : {}", size, generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(TestClass[].class);

--- a/src/test/java/io/javarig/generator/StringGenerationTest.java
+++ b/src/test/java/io/javarig/generator/StringGenerationTest.java
@@ -1,7 +1,6 @@
 package io.javarig.generator;
 
 import io.javarig.RandomInstanceGenerator;
-import io.javarig.config.Configuration;
 import io.javarig.config.DefaultConfigValues;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +33,7 @@ public class StringGenerationTest {
     @Test
     public void shouldGenerateStringWithExactSize() {
         int size = 20;
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withSize(size));
+        Object generated = randomInstanceGenerator.withSize(size).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -45,7 +44,7 @@ public class StringGenerationTest {
     public void shouldGenerateStringWithSizeBetween() {
         int minSize = 20;
         int maxSize = 40;
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withSize(minSize, maxSize));
+        Object generated = randomInstanceGenerator.withSize(minSize, maxSize).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -54,7 +53,7 @@ public class StringGenerationTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "[a-zA-Z0-9,;:!?]"})
     public void shouldGenerateStringMatchingRegexPatternBellowGivenMinimumLength(String regexPattern) {
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withRegexPattern(regexPattern));
+        Object generated = randomInstanceGenerator.withRegexPattern(regexPattern).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -64,7 +63,7 @@ public class StringGenerationTest {
     @Test
     public void shouldGenerateStringMatchingRegexPatternOverGivenMaximumLength() {
         String regexPattern = "abcdefghijklmnopqrstuvwxyz";
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withRegexPattern(regexPattern));
+        Object generated = randomInstanceGenerator.withRegexPattern(regexPattern).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -74,7 +73,7 @@ public class StringGenerationTest {
     @Test
     public void shouldGenerateStringMatchingRegexPattern() {
         String regexPattern = "[a-z][A-Z]*[0-9]+a[a(b;c][12]";
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withRegexPattern(regexPattern));
+        Object generated = randomInstanceGenerator.withRegexPattern(regexPattern).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -85,7 +84,7 @@ public class StringGenerationTest {
     public void shouldGenerateStringMatchingRegexPatternWhileIgnoringUnsupportedCharacters() {
         String regexPattern = "[a-z]^[A-Z]*[0-9]+$a[ab;\\c$$$$^^i][12]";
         String  temp = removeUnsupportedRegexCharacters(regexPattern);
-        Object generated = randomInstanceGenerator.generate(String.class, Configuration.withRegexPattern(regexPattern));
+        Object generated = randomInstanceGenerator.withRegexPattern(regexPattern).generate(String.class);
         log.info("shouldGenerateString : {}", generated);
         assertThat(generated).isNotNull();
         assertThat(generated).isInstanceOf(String.class);
@@ -97,7 +96,7 @@ public class StringGenerationTest {
         int minSize = 40;
         int maxSize = 20;
         assertThatThrownBy(() -> {//when
-            randomInstanceGenerator.generate(String.class, Configuration.withSize(minSize, maxSize));
+            randomInstanceGenerator.withSize(minSize, maxSize).generate(String.class);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Start value must be smaller than end value.");
     }
@@ -106,7 +105,7 @@ public class StringGenerationTest {
     public void shouldThrowIllegalArgumentExceptionGivenStringHavingMinSizeSameASMaxSize() {
         int size = 30;
         assertThatThrownBy(() -> {//when
-            randomInstanceGenerator.generate(String.class, Configuration.withSize(size, size));
+            randomInstanceGenerator.withSize(size, size).generate(String.class);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Start value must be smaller than end value.");
     }
@@ -114,7 +113,7 @@ public class StringGenerationTest {
     public void shouldThrowIllegalArgumentExceptionWhenGivenNegativeSize() {
         int size = -20;
         assertThatThrownBy(() -> {//when
-            randomInstanceGenerator.generate(String.class, Configuration.withSize(size));
+            randomInstanceGenerator.withSize(size).generate(String.class);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Size must be non-negative.");
     }

--- a/src/test/java/io/javarig/generator/collection/CollectionGenerationTest.java
+++ b/src/test/java/io/javarig/generator/collection/CollectionGenerationTest.java
@@ -2,7 +2,6 @@ package io.javarig.generator.collection;
 
 import io.javarig.ParameterizedTypeImpl;
 import io.javarig.RandomInstanceGenerator;
-import io.javarig.config.Configuration;
 import io.javarig.exception.InvalidGenericParametersNumberException;
 import io.javarig.exception.JavaRIGInternalException;
 import io.javarig.generator.collection.list.ListGenerator;
@@ -56,7 +55,7 @@ public class CollectionGenerationTest {
         int size = 20;
         Class<?> type = String.class;
         //when
-        Object generated = randomInstanceGenerator.generate(collectionClass, Configuration.withSize(size), type);
+        Object generated = randomInstanceGenerator.withSize(size).generate(collectionClass, type);
         //then
         log.info("shouldReturn{}WithExactSize : {}",collectionClass.getSimpleName(), generated);
         assertThat(generated).isNotNull();
@@ -75,7 +74,7 @@ public class CollectionGenerationTest {
         int maxSize = 40;
         Class<?> type = String.class;
         //when
-        Object generated = randomInstanceGenerator.generate(collectionClass, Configuration.withSize(minSize, maxSize), type);
+        Object generated = randomInstanceGenerator.withSize(minSize, maxSize).generate(collectionClass, type);
         //then
         log.info("shouldReturnListWithSizeBetween : {}", generated);
         assertThat(generated).isNotNull();
@@ -108,7 +107,7 @@ public class CollectionGenerationTest {
     public void shouldThrowIllegalArgumentExceptionGivenMinSizeEqualsMaxSize(Class<?> collectionClass) {
         int size = 30;
         assertThatThrownBy(() -> {//when
-            randomInstanceGenerator.generate(collectionClass, Configuration.withSize(size, size));
+            randomInstanceGenerator.withSize(size, size).generate(collectionClass);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Start value must be smaller than end value.");
     }

--- a/src/test/java/io/javarig/generator/map/MapGenerationTest.java
+++ b/src/test/java/io/javarig/generator/map/MapGenerationTest.java
@@ -2,7 +2,6 @@ package io.javarig.generator.map;
 
 import io.javarig.ParameterizedTypeImpl;
 import io.javarig.RandomInstanceGenerator;
-import io.javarig.config.Configuration;
 import io.javarig.exception.InvalidGenericParametersNumberException;
 import io.javarig.exception.JavaRIGInternalException;
 import io.javarig.generator.map.MapGenerator;
@@ -60,7 +59,7 @@ public class MapGenerationTest {
         Class<?> valueType = Integer.class;
 
         //when
-        Object generated = randomInstanceGenerator.generate(mapClass, Configuration.withSize(size), keyType, valueType);
+        Object generated = randomInstanceGenerator.withSize(size).generate(mapClass, keyType, valueType);
         //then
         log.info("shouldReturnMapWithExactSize of type {} : {}", mapClass.getName(), generated);
         assertThat(generated).isNotNull();
@@ -85,7 +84,7 @@ public class MapGenerationTest {
         Class<?> valueType = Integer.class;
 
         //when
-        Object generated = randomInstanceGenerator.generate(mapClass, Configuration.withSize(minSize, maxSize), keyType, valueType);
+        Object generated = randomInstanceGenerator.withSize(minSize, maxSize).generate(mapClass, keyType, valueType);
         //then
         log.info("shouldReturnMapWithSizeBetween of type {} : {}", mapClass.getName(), generated);
         assertThat(generated).isNotNull();

--- a/src/test/java/io/javarig/testclasses/ConfigurationTestClass.java
+++ b/src/test/java/io/javarig/testclasses/ConfigurationTestClass.java
@@ -1,0 +1,11 @@
+package io.javarig.testclasses;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ConfigurationTestClass {
+    private String s;
+    private List<Integer> l; 
+}


### PR DESCRIPTION
Fix the bug by creating withX methods in RIG class that sets the oneTimeConfig using generalConfig